### PR TITLE
feat: add mobile home screen

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,37 +1,154 @@
-:root {
-  --teal: #00c9b8;
-  --navy: #002393;
-}
+/* Mobile home screen styles */
 
-body {
-  margin: 0;
+.mobile-container {
+  position: relative;
+  margin: 0 auto;
+  height: 100vh;
+  max-width: 420px;
+  background: #f5f5f5;
+  border: 1px solid #ddd;
+  display: flex;
+  flex-direction: column;
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  background-color: var(--navy);
-  color: #ffffff;
-  text-align: center;
+  color: #111;
 }
 
-.header {
-  background-color: var(--teal);
-  padding: 1rem;
-  color: var(--navy);
+.content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  padding-bottom: 80px; /* space for bottom nav */
 }
 
-main {
-  padding: 2rem;
+.greeting p {
+  margin: 0 0 16px 0;
+  font-size: 1.1rem;
 }
 
-.primary-btn {
-  background-color: var(--teal);
-  color: var(--navy);
+.username {
+  font-weight: 600;
+}
+
+.carousel {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  margin-bottom: 24px;
+}
+
+.reward-card {
+  min-width: 60%;
+  background: #000;
+  color: #fff;
+  padding: 20px;
+  border-radius: 12px;
+  flex-shrink: 0;
+  font-size: 0.9rem;
+}
+
+.section {
+  margin-bottom: 24px;
+}
+
+.section-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #555;
+  margin-bottom: 12px;
+}
+
+.money-items {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.money-card {
+  background: #fff;
+  border-radius: 8px;
+  padding: 12px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.9rem;
+}
+
+.amount {
+  color: #0a8f08;
+  font-weight: 600;
+}
+
+.bill-card {
+  background: #fff;
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.bill-info {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.9rem;
+}
+
+.bill-title {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.pay-btn {
+  background: #000;
+  color: #fff;
   border: none;
-  border-radius: 4px;
-  padding: 0.75rem 1.5rem;
-  font-size: 1rem;
+  padding: 8px 12px;
+  border-radius: 6px;
   cursor: pointer;
 }
 
-.primary-btn:hover {
-  opacity: 0.9;
+.grid-icons {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
 }
 
+.icon-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 0.75rem;
+  text-align: center;
+}
+
+.icon-circle {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: 1px solid #ccc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  background: #fff;
+  margin-bottom: 6px;
+}
+
+.bottom-nav {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 60px;
+  background: #fff;
+  border-top: 1px solid #ccc;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+}
+
+.nav-item {
+  text-decoration: none;
+  color: #555;
+  font-size: 0.8rem;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,15 +1,105 @@
 import './App.css'
 
+// Home screen based on the provided fintech app mockups.
+// The layout emulates a mobile device by constraining the
+// width and fixing the bottom navigation bar while keeping
+// the main content scrollable.
+
 function App() {
   return (
-    <div className="app">
-      <header className="header">
-        <h1>Bankit</h1>
-      </header>
-      <main>
-        <p>Welcome to the Bankit fintech demo app.</p>
-        <button className="primary-btn">Get Started</button>
-      </main>
+    <div className="mobile-container">
+      <div className="content">
+        {/* Greeting */}
+        <div className="greeting">
+          <p>
+            hello, <span className="username">Ashish</span>
+          </p>
+        </div>
+
+        {/* Rewards carousel */}
+        <div className="carousel">
+          <div className="reward-card">UNCLAIMED REWARDS</div>
+          <div className="reward-card">Daily Rewards</div>
+          <div className="reward-card">Gift Cards</div>
+        </div>
+
+        {/* Money Matters section */}
+        <section className="section">
+          <h3 className="section-title">MONEY MATTERS</h3>
+          <div className="money-items">
+            <div className="money-card">
+              <span>CRED cash</span>
+              <span className="amount">₹45,000</span>
+            </div>
+            <div className="money-card">
+              <span>INDB xx 8358</span>
+              <span className="amount">check</span>
+            </div>
+          </div>
+        </section>
+
+        {/* Upcoming Bills section */}
+        <section className="section">
+          <h3 className="section-title">UPCOMING BILLS</h3>
+          <div className="bill-card">
+            <div className="bill-info">
+              <span className="bill-title">RBL Bank</span>
+              <span className="bill-detail">XXXX 2299</span>
+            </div>
+            <button className="pay-btn">Pay ₹17,001</button>
+          </div>
+        </section>
+
+        {/* Explore Section */}
+        <section className="section">
+          <h3 className="section-title">EXPLORE CRED</h3>
+          <div className="grid-icons">
+            <div className="icon-item">
+              <div className="icon-circle">📱</div>
+              <span className="icon-label">bills & recharges</span>
+            </div>
+            <div className="icon-item">
+              <div className="icon-circle">💸</div>
+              <span className="icon-label">pay contacts</span>
+            </div>
+            <div className="icon-item">
+              <div className="icon-circle">🛍️</div>
+              <span className="icon-label">shop</span>
+            </div>
+            <div className="icon-item">
+              <div className="icon-circle">📊</div>
+              <span className="icon-label">CIBIL score</span>
+            </div>
+            <div className="icon-item">
+              <div className="icon-circle">💰</div>
+              <span className="icon-label">cash</span>
+            </div>
+            <div className="icon-item">
+              <div className="icon-circle">🎓</div>
+              <span className="icon-label">education fees</span>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      {/* Bottom navigation */}
+      <nav className="bottom-nav">
+        <a href="#" className="nav-item">
+          Home
+        </a>
+        <a href="#" className="nav-item">
+          Cards
+        </a>
+        <a href="#" className="nav-item">
+          UPI
+        </a>
+        <a href="#" className="nav-item">
+          Rewards
+        </a>
+        <a href="#" className="nav-item">
+          More
+        </a>
+      </nav>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add scrollable mobile container home screen with rewards, bill and explore sections
- include fixed bottom navigation bar for app-wide links

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac873cfc888333861eedfae490ce9f