### PR TITLE
feat: add wallet screen and enhanced UPI flow

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -120,6 +120,7 @@
   align-items: center;
   font-size: 0.75rem;
   text-align: center;
+  cursor: pointer;
 }
 
 .icon-circle {
@@ -295,6 +296,38 @@
 }
 
 .upi-flow button {
+  padding: 10px;
+  background: var(--primary-color);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.pay-mode {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.pay-mode button {
+  flex: 1;
+  padding: 8px;
+  background: #eee;
+  border: none;
+  cursor: pointer;
+}
+
+.pay-mode .active {
+  background: var(--primary-color);
+  color: #fff;
+}
+
+.wallet-screen {
+  padding: 16px;
+}
+
+.activate-btn {
   padding: 10px;
   background: var(--primary-color);
   color: #fff;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,14 +1,15 @@
 import './App.css'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import {
   FaHome,
-  FaCreditCard,
   FaExchangeAlt,
   FaEllipsisH,
-  FaUserCircle
+  FaUserCircle,
+  FaWallet
 } from 'react-icons/fa'
 import UPIFlow from './UPIFlow'
 import ProfileDrawer from './ProfileDrawer'
+import Wallet from './Wallet'
 
 const sections = [
   {
@@ -78,9 +79,24 @@ const sections = [
 function App() {
   const [currentPage, setCurrentPage] = useState('home')
   const [profileOpen, setProfileOpen] = useState(false)
+  const [upiDetails, setUpiDetails] = useState(() => {
+    const saved = localStorage.getItem('upiDetails')
+    return saved ? JSON.parse(saved) : null
+  })
+
+  useEffect(() => {
+    if (upiDetails) {
+      localStorage.setItem('upiDetails', JSON.stringify(upiDetails))
+    }
+  }, [upiDetails])
+
+  const handleRegister = details => {
+    setUpiDetails(details)
+  }
 
   return (
-    <div className="mobile-container">
+    <>
+      <div className="mobile-container">
       <header className="app-header">
         <h1 className="app-title">Bankit</h1>
         <button
@@ -115,7 +131,13 @@ function App() {
                 <h3 className="section-title">{section.title}</h3>
                 <div className="grid-icons">
                   {section.items.map((item) => (
-                    <div className="icon-item" key={item.label}>
+                    <div
+                      className="icon-item"
+                      key={item.label}
+                      onClick={() => {
+                        if (item.label === 'scan & pay') setCurrentPage('upi')
+                      }}
+                    >
                       <div className="icon-circle">{item.icon}</div>
                       <span className="icon-label">{item.label}</span>
                     </div>
@@ -126,7 +148,15 @@ function App() {
           </>
         )}
 
-        {currentPage === 'upi' && <UPIFlow onClose={() => setCurrentPage('home')} />}
+        {currentPage === 'upi' && (
+          <UPIFlow
+            onClose={() => setCurrentPage('home')}
+            registered={Boolean(upiDetails)}
+            onRegister={handleRegister}
+          />
+        )}
+
+        {currentPage === 'wallet' && <Wallet />}
       </div>
 
       {/* Bottom navigation */}
@@ -135,9 +165,9 @@ function App() {
           <FaHome className="nav-icon" />
           <span>Home</span>
         </a>
-        <a href="#" className="nav-item">
-          <FaCreditCard className="nav-icon" />
-          <span>Cards</span>
+        <a href="#" className="nav-item" onClick={() => setCurrentPage('wallet')}>
+          <FaWallet className="nav-icon" />
+          <span>Wallet</span>
         </a>
         <a
           href="#"
@@ -155,9 +185,14 @@ function App() {
           <span>More</span>
         </a>
       </nav>
-
-      {profileOpen && <ProfileDrawer onClose={() => setProfileOpen(false)} />}
     </div>
+    {profileOpen && (
+      <ProfileDrawer
+        onClose={() => setProfileOpen(false)}
+        upiDetails={upiDetails}
+      />
+    )}
+    </>
   )
 }
 

--- a/frontend/src/ProfileDrawer.jsx
+++ b/frontend/src/ProfileDrawer.jsx
@@ -1,4 +1,4 @@
-function ProfileDrawer ({ onClose }) {
+function ProfileDrawer ({ onClose, upiDetails }) {
   return (
     <div className="profile-overlay" onClick={onClose}>
       <div className="profile-drawer" onClick={e => e.stopPropagation()}>
@@ -9,6 +9,7 @@ function ProfileDrawer ({ onClose }) {
           <div className="avatar">A</div>
           <div>
             <h2>Ashish Dabas</h2>
+            {upiDetails && <p className="membership">UPI ID: {upiDetails.upiId}</p>}
             <p className="membership">member since Jul, 2022</p>
           </div>
         </div>

--- a/frontend/src/UPIFlow.jsx
+++ b/frontend/src/UPIFlow.jsx
@@ -1,12 +1,13 @@
 import { useState } from 'react'
 
-function UPIFlow ({ onClose }) {
-  const [step, setStep] = useState(0)
+function UPIFlow ({ onClose, registered, onRegister }) {
+  const [step, setStep] = useState(registered ? 4 : 0)
   const [bank, setBank] = useState('')
   const [upiId, setUpiId] = useState('')
   const [pin, setPin] = useState('')
   const [payee, setPayee] = useState('')
   const [amount, setAmount] = useState('')
+  const [mode, setMode] = useState('upi')
 
   return (
     <div className="upi-flow">
@@ -55,6 +56,7 @@ function UPIFlow ({ onClose }) {
         <form
           onSubmit={e => {
             e.preventDefault()
+            onRegister({ bank, upiId })
             setStep(4)
           }}
         >
@@ -66,32 +68,48 @@ function UPIFlow ({ onClose }) {
             onChange={e => setPin(e.target.value)}
             required
           />
-          <button type="submit">Continue</button>
+          <button type="submit">Register</button>
         </form>
       )}
       {step === 4 && (
-        <form
-          onSubmit={e => {
-            e.preventDefault()
-            setStep(5)
-          }}
-        >
-          <h2>Make Payment</h2>
-          <input
-            placeholder="Payee UPI ID"
-            value={payee}
-            onChange={e => setPayee(e.target.value)}
-            required
-          />
-          <input
-            type="number"
-            placeholder="Amount"
-            value={amount}
-            onChange={e => setAmount(e.target.value)}
-            required
-          />
-          <button type="submit">Pay</button>
-        </form>
+        <div>
+          <h2>Scan & Pay</h2>
+          <div className="pay-mode">
+            <button
+              className={mode === 'upi' ? 'active' : ''}
+              onClick={() => setMode('upi')}
+            >
+              UPI ID
+            </button>
+            <button
+              className={mode === 'contact' ? 'active' : ''}
+              onClick={() => setMode('contact')}
+            >
+              Contacts
+            </button>
+          </div>
+          <form
+            onSubmit={e => {
+              e.preventDefault()
+              setStep(5)
+            }}
+          >
+            <input
+              placeholder={mode === 'upi' ? 'Payee UPI ID' : 'Contact name'}
+              value={payee}
+              onChange={e => setPayee(e.target.value)}
+              required
+            />
+            <input
+              type="number"
+              placeholder="Amount"
+              value={amount}
+              onChange={e => setAmount(e.target.value)}
+              required
+            />
+            <button type="submit">Pay</button>
+          </form>
+        </div>
       )}
       {step === 5 && (
         <div>

--- a/frontend/src/Wallet.jsx
+++ b/frontend/src/Wallet.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+function Wallet () {
+  return (
+    <div className="wallet-screen">
+      <h2>Activate Wallet</h2>
+      <p>Enable your wallet to start using digital payments.</p>
+      <button className="activate-btn">Activate Wallet</button>
+    </div>
+  )
+}
+
+export default Wallet


### PR DESCRIPTION
## Summary
- persist UPI registration and redirect subsequent launches to Scan & Pay
- show registered UPI ID in profile drawer
- add wallet activation screen and bottom nav entry

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac9af3ef688333b4b29b5ef4b72d0f